### PR TITLE
Harden app configuration and SECRET_KEY contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,48 @@ We're always looking to improve HamPy and bring more features to our users. Here
 ## Documentation :book:
 
 ### Installation
-> [Instructions Forthcoming]
+1. Create and activate a virtual environment.
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install project dependencies.
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+### Configuration
+
+HamPy uses environment variables for runtime configuration:
+
+- `SECRET_KEY`  
+  - **Development:** optional. If omitted, HamPy uses a local-only fallback key (`dev-insecure-change-me`).
+  - **Production (`HAMPY_ENV=production`): required.** Startup fails if `SECRET_KEY` is not set.
+- `HAMPY_ENV`  
+  - Optional environment selector (`development` by default).
+  - Set to `production` to enforce production safety checks.
+
+Example development configuration:
+
+```bash
+export HAMPY_ENV=development
+export SECRET_KEY="replace-with-a-local-dev-secret"
+```
+
+Example production configuration:
+
+```bash
+export HAMPY_ENV=production
+export SECRET_KEY="strong-random-secret-key"
+```
 
 ### Usage
-> [Instructions Forthcoming]
+Initialize the database and run the app:
+
+```bash
+flask --app Contacts init-db
+flask --app Contacts run --debug
+```
 
 ---
 
@@ -54,4 +92,3 @@ While this is currently a personal project, I may open it up to contributions in
 ---
 
 Stay tuned for more updates and thank you for choosing HamPy for your ham radio tracking needs! :smile: :radio:
-

--- a/__init__.py
+++ b/__init__.py
@@ -2,13 +2,33 @@ import os
 
 from flask import Flask
 
+
+def _get_environment():
+    return os.environ.get('HAMPY_ENV', os.environ.get('FLASK_ENV', 'development')).lower()
+
+
+def _get_secret_key(environment):
+    configured_secret = os.environ.get('SECRET_KEY')
+
+    if configured_secret:
+        return configured_secret
+
+    if environment == 'production':
+        raise RuntimeError(
+            'SECRET_KEY environment variable is required when HAMPY_ENV=production.'
+        )
+
+    return 'dev-insecure-change-me'
+
+
 def create_app(test_config=None):
     #create and configure app
     app = Flask(__name__, instance_relative_config=True)
+    environment = _get_environment()
     app.config.from_mapping(
-        #DONT FORGET TO CHANGE BEFORE PUSHING TO PRODUCTION
-        SECRET_KEY='os.environ(secret_key)',
+        SECRET_KEY=_get_secret_key(environment),
         DATABASE=os.path.join(app.instance_path, 'contacts.sqlite'),
+        HAMPY_ENV=environment,
     )
 
     if test_config is None:
@@ -42,4 +62,3 @@ def create_app(test_config=None):
 
 
     return app    
-

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,73 @@
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+
+def load_contacts_package():
+    repo_root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        'Contacts',
+        repo_root / '__init__.py',
+        submodule_search_locations=[str(repo_root)],
+    )
+    package = importlib.util.module_from_spec(spec)
+    sys.modules['Contacts'] = package
+    spec.loader.exec_module(package)
+    return package
+
+
+class AppConfigTests(unittest.TestCase):
+    def create_app(self):
+        contacts_package = load_contacts_package()
+        temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(temp_dir.cleanup)
+
+        app = contacts_package.create_app(
+            {'TESTING': True, 'DATABASE': str(Path(temp_dir.name) / 'test.sqlite')}
+        )
+        return app
+
+    def test_dev_defaults_to_safe_local_secret_key(self):
+        with patch.dict(
+            os.environ, {'SECRET_KEY': '', 'HAMPY_ENV': 'development'}, clear=False
+        ):
+            os.environ.pop('SECRET_KEY', None)
+            app = self.create_app()
+            self.assertEqual(app.config['SECRET_KEY'], 'dev-insecure-change-me')
+            self.assertEqual(app.config['HAMPY_ENV'], 'development')
+
+    def test_secret_key_reads_from_environment(self):
+        with patch.dict(
+            os.environ,
+            {'SECRET_KEY': 'env-driven-secret', 'HAMPY_ENV': 'development'},
+            clear=False,
+        ):
+            app = self.create_app()
+            self.assertEqual(app.config['SECRET_KEY'], 'env-driven-secret')
+
+    def test_production_requires_secret_key(self):
+        with patch.dict(
+            os.environ, {'SECRET_KEY': '', 'HAMPY_ENV': 'production'}, clear=False
+        ):
+            os.environ.pop('SECRET_KEY', None)
+            contacts_package = load_contacts_package()
+            with self.assertRaises(RuntimeError):
+                contacts_package.create_app({'TESTING': True})
+
+    def test_production_allows_env_secret_key(self):
+        with patch.dict(
+            os.environ,
+            {'SECRET_KEY': 'prod-secret', 'HAMPY_ENV': 'production'},
+            clear=False,
+        ):
+            app = self.create_app()
+            self.assertEqual(app.config['SECRET_KEY'], 'prod-secret')
+            self.assertEqual(app.config['HAMPY_ENV'], 'production')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Motivation
- Fix incorrect `SECRET_KEY` initialization that used a literal placeholder instead of reading the environment. 
- Enforce a clear configuration contract so production requires an explicit `SECRET_KEY` and development gets a safe local default. 
- Add tests and docs to make the contract explicit and verifiable for developers and CI.

### Description
- Updated `__init__.py` to add `_get_environment()` and `_get_secret_key()` helpers and wire `create_app()` to resolve `SECRET_KEY` from the environment and expose `HAMPY_ENV` in config. 
- `create_app()` now raises a `RuntimeError` when `HAMPY_ENV=production` and `SECRET_KEY` is not set, while returning a local fallback (`dev-insecure-change-me`) in non-production. 
- Added `tests/test_config.py` with unit tests covering the development fallback, environment-driven secret, production failure when missing, and production success when provided. 
- Updated `README.md` with installation steps, configuration contract, example env setups, and example usage commands (`flask --app Contacts init-db` / `flask --app Contacts run --debug`).

### Testing
- Ran unit tests with `python -m unittest discover -s tests -v` and all tests succeeded. 
- The test run covered the new config tests in `tests/test_config.py` and the existing schema/seed regression test in `tests/test_schema_seed.py`, with 5 tests run and all passing. 
- The `create_app` behavior was exercised via the new tests which import the package from `__init__.py` and verify the expected production/development behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cd2d4d5320832590054aedcdf0d31f)