### PR TITLE
Update templates: app title, textarea rendering, and login layout

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<title>{% block title %}{% endblock %} - Flaskr</title>
+<title>{% block title %}{% endblock %} - HamPy</title>
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-rbsA2VBKQhggwzxH7pPCaAqO46MgnOM80zW1RWuH61DGLwZJEdK2Kadq2F9CUG65" crossorigin="anonymous">    
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-kenU1KFdBIe4zVF0s0G1M5b4hcpxyD9F7jL+jjXkk+Q2h455rYXK/7HAuoJl+0I4" crossorigin="anonymous"></script>
 <nav class="navbar navbar-expand-lg bg-light">

--- a/templates/log/update.html
+++ b/templates/log/update.html
@@ -9,7 +9,7 @@
     <label for="callsign">Callsign</label>
     <input name="callsign" id="callsign"value="{{ request.form['callsign'] or contact['callsign'] }}" required>
     <label for="comments">comments</label>
-    <textarea name="comments" id="comments" value="{{ request.form['comments'] or contact['comments'] }}"></textarea>
+    <textarea name="comments" id="comments">{{ request.form['comments'] or contact['comments'] }}</textarea>
     <label for="frequency">frequency</label>
     <input name="frequency" id="frequency" value="{{ request.form['frequency'] or contact['frequency'] }}">
     <label for="mode">mode</label>

--- a/templates/login.html
+++ b/templates/login.html
@@ -5,8 +5,7 @@
 {% endblock %}
 
 {% block content %}
-<body class="text-center bg-light text-dark">
-    <main class="form-signin w-25 m-auto container">
+<main class="form-signin w-25 m-auto container text-center bg-light text-dark">
         <form method="post">
             <h1 class="h3 mb-3 fw-normal">Please sign in</h1>
             <div class="form-floating">
@@ -22,7 +21,5 @@
             <button class="w-100 btn btn-lg btn-primary" type="submit">Sign in</button>
             <p class="mt-5 mb-3 text-muted">© Mike Gregoire 2022 - Get the source code on my <a href="https://github.com/mgregoire254/Flask-Ham-Contact-Log">Github</a></p>
           </form>
-    </main>
-</body>  
-
+</main>
 {% endblock %}


### PR DESCRIPTION
### Motivation
- Correct several template issues: update the site title, ensure the `comments` textarea preserves existing content, and fix the login form layout markup for proper styling.

### Description
- Change site title in `templates/base.html` from `Flaskr` to `HamPy`.
- Fix `comments` field in `templates/log/update.html` by placing the value between `<textarea>` tags instead of using a `value` attribute.
- Remove the stray `body` wrapper and move layout classes onto the `main` element in `templates/login.html` to correct form centering and Bootstrap styling.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ceb0662964832596368c8530a10bda)