### PR TITLE
Fix packaging/install consistency for Contacts project

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include Contact/schema.sql
-graft Contact/static
-graft Contact/templates
+include schema.sql
+recursive-include static *
+recursive-include templates *
 global-exclude *.pyc

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,13 @@
-from setuptools import find_packages, setup
+from setuptools import setup
+
 
 setup(
     name='Contacts',
     version='1.0.0',
-    packages=find_packages(),
+    packages=['Contacts'],
+    package_dir={'Contacts': '.'},
     include_package_data=True,
     install_requires=[
-    'flask',
+        'flask',
     ],
 )


### PR DESCRIPTION
### Motivation
- `MANIFEST.in` referenced `Contact/...` (singular) which did not match the repository layout and could omit runtime assets from source distributions.
- The project tests and imports use the `Contacts` package rooted at the repository, so packaging should map that package name to the repository root for consistent installs.

### Description
- Updated `MANIFEST.in` to include `schema.sql` and to `recursive-include` the repository `static` and `templates` directories instead of the stale `Contact/...` paths.
- Updated `setup.py` to declare `packages=['Contacts']` and `package_dir={'Contacts': '.'}` to align the installed package layout with the runtime import style while preserving `include_package_data=True` and `install_requires`. 
- No application code changes were made; only packaging metadata was modified.

### Testing
- Ran the unit test suite with `python -m unittest discover -s tests -v`, and all tests passed (`10 tests OK`).
- Built a source distribution with `python setup.py sdist`, which completed successfully and included `schema.sql`, static assets, templates, and the root package modules in the generated archive.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cf356dddd083259a27cf1016bb8d1c)